### PR TITLE
Fix error caused when there's no body from the request

### DIFF
--- a/src/middlewares/guard.ts
+++ b/src/middlewares/guard.ts
@@ -51,7 +51,7 @@ export class Guard {
     }
 
     middleware = (req: Request, res: Response, next: NextFunction) => {
-        const token = req.headers[this.options.tokenField] || req.body[this.options.tokenField] || req.query[this.options.tokenField];
+        const token = req.headers[this.options.tokenField] || req.query[this.options.tokenField];
         if (!token) {
             this.callback ? this.callback(req, res, next, ERROR_NO_TOKEN) : res.status(401).json({error: "No token provided"});
             return;

--- a/src/middlewares/guard.ts
+++ b/src/middlewares/guard.ts
@@ -51,7 +51,7 @@ export class Guard {
     }
 
     middleware = (req: Request, res: Response, next: NextFunction) => {
-        const token = req.headers[this.options.tokenField] || req.query[this.options.tokenField];
+        const token = req.headers[this.options.tokenField] || (req.body && req.body[this.options.tokenField]) || req.query[this.options.tokenField];
         if (!token) {
             this.callback ? this.callback(req, res, next, ERROR_NO_TOKEN) : res.status(401).json({error: "No token provided"});
             return;


### PR DESCRIPTION
Trying to use the middleware as it is just errors every time as it looks for the token in the body, even when there is none.

Adding a check for the body before looking for the token there 